### PR TITLE
added npm main pointing at index.js, so require('pogo') works

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "pogo": "bin/pogo",
         "mogo": "bin/mogo"
     },
+    "main": "index.js",
     "devDependencies": {
         "mocha": "",
         "should": ""


### PR DESCRIPTION
I think package.json needed a "main" element, for require('pogo') to work. Was it omitted on purpose?
