### PR TITLE
make bluebird a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"

--- a/bin/pogo
+++ b/bin/pogo
@@ -10,7 +10,7 @@ cli.option("-s, --if-stale only compile files if they are out of date");
 cli.option("-h, --help print herlp!");
 cli.option("--debug run the node debugger");
 cli.option("--debug-brk run the node debugger, breaking on the first line");
-cli.option("-p, --promises=<promise-module> select a promises module, the default is none");
+cli.option("-p, --promises=<promise-module> select a promises module, the default is 'none' (uses the global Promise)");
 options = cli.parse(process.argv.slice(2));
 
 var commandLine = require('..');

--- a/bin/pogo
+++ b/bin/pogo
@@ -10,7 +10,7 @@ cli.option("-s, --if-stale only compile files if they are out of date");
 cli.option("-h, --help print herlp!");
 cli.option("--debug run the node debugger");
 cli.option("--debug-brk run the node debugger, breaking on the first line");
-cli.option("-p, --promises=<promise-module> select a promises module, the default is bluebird");
+cli.option("-p, --promises=<promise-module> select a promises module, the default is none");
 options = cli.parse(process.argv.slice(2));
 
 var commandLine = require('..');

--- a/lib/debugPogo.js
+++ b/lib/debugPogo.js
@@ -34,7 +34,7 @@
         var childProcess;
         childProcess = require("child_process");
         return childProcess.spawn(process.argv[0], nodeArguments, {
-            customFds: [ 0, 1, 2 ]
+            stdio: 'inherit'
         });
     };
 }).call(this);

--- a/lib/debugPogo.pogo
+++ b/lib/debugPogo.pogo
@@ -26,4 +26,4 @@ node arguments =
 
 exports.debug pogo () =
     child process = require 'child_process'
-    child process.spawn (process.argv.0, node arguments, custom fds: [0, 1, 2])
+    child process.spawn (process.argv.0, node arguments, stdio: 'inherit')

--- a/lib/parser/codeGenerator.js
+++ b/lib/parser/codeGenerator.js
@@ -113,7 +113,7 @@ exports.codeGenerator = function (options) {
 };
 
 function promisesModule(options) {
-  var moduleName = (options && options.promises) || 'bluebird';
+  var moduleName = (options && options.promises) || 'none';
   
   if (moduleName === 'none') {
     return undefined;

--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
     "uglify-js": "~2.4.13",
     "underscore": "1.4.4"
   },
-  "peerDependencies": {
-    "bluebird": "^2.2.1"
-  },
   "keywords": [
     "language",
     "pogo"

--- a/test/shell/pogoSpec.pogo
+++ b/test/shell/pogoSpec.pogo
@@ -242,10 +242,10 @@ describe '`pogo` (interactive)'
 
 describe 'pogo --promises'
   promisesTests (runPogoCommand) =
-    it 'default is set to bluebird'
+    it 'default is set to none, using the global Promise'
       source = "wait () = setTimeout ^ 1!
-                bluebird = require 'bluebird'
-                console.log (bluebird == Promise)"
+                global.Promise = 'global promise'
+                console.log ('global promise' == Promise)"
       write (source) toFile "promiseTest.pogo"!
       output = runPogoCommand "promiseTest.pogo"!
       output.stdout.should.equal "true\n"

--- a/test/shell/pogoSpec.pogo
+++ b/test/shell/pogoSpec.pogo
@@ -135,7 +135,7 @@ describe 'debugging'
         it 'starts remote debugging'
             write "console.log 'bug!'" toFile "toDebug.pogo"!
             pogoOutput = run 'pogo --debug toDebug.pogo'!
-            pogoOutput.stderr.should.equal "debugger listening on port 5858\n"
+            pogoOutput.stderr.should.equal "Debugger listening on port 5858\n"
             pogoOutput.stdout.should.equal "bug!\n"
 
 describe '`pogo` (interactive)'


### PR DESCRIPTION
With npm 3 peer dependencies are no longer automatically installed and at the moment since bluebird is the default promises node module, it should become a dependency.

An alternative approach would be to do have no default promises node modules which would allow bluebird to be removed as a dependency
